### PR TITLE
React Native 0.59 Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,7 @@ react-native link kumulos-react-native
 
 ### Android Linking Steps (required)
 
-To complete the linking process for Android, you need to ensure your project uses the following versions for tools & libraries:
-
--   Gradle plugin v3.1.3 or greater
--   Build tools v23.0.3 or greater
--   Support library v27.+
-
-In addition, you must add the following to your `android/app/build.gradle` file:
+You must add the following to your `android/app/build.gradle` file:
 
 ```
 android {
@@ -27,11 +21,6 @@ android {
         exclude 'META-INF/NOTICE'
         exclude 'META-INF/ASL2.0'
         exclude 'META-INF/LICENSE'
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 ```
@@ -58,3 +47,10 @@ Pull requests are welcome for any improvements you might wish to make. If it's s
 ## License
 
 This project is licensed under the MIT license with portions licensed under the BSD 2-Clause license. See our LICENSE file and individual source files for more information.
+
+## React Native Version Support
+
+| RN Version        | SDK Version | Docs                                                                           |
+| ----------------- | ----------- | ------------------------------------------------------------------------------ |
+| >= 0.59           | 3.0.0       | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/master/README.md) |
+| >= 0.46 && < 0.59 | 2.1.0       | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/2.1.0/README.md)  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kumulos-react-native",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -610,9 +610,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "kumulos-react-native",
-  "version": "2.1.0",
-  "description": "Official SDK for integrating Kumulos services with your React Native projects",
-  "main": "src/index.js",
-  "types": "index.d.ts",
-  "repository": "https://github.com/Kumulos/KumulosSdkReactNative",
-  "author": "Kumulos Ltd. <support@kumulos.com>",
-  "license": "MIT",
-  "dependencies": {
-    "base-64": "^0.1.0",
-    "raven-js": "^3.26.3"
-  },
-  "peerDependencies": {
-    "react-native": ">=0.46.0"
-  },
-  "devDependencies": {
-    "eslint": "^4.18.2"
-  },
-  "rnpm": {
-    "android": {
-      "sourceDir": "./src/android"
+    "name": "kumulos-react-native",
+    "version": "3.0.0",
+    "description": "Official SDK for integrating Kumulos services with your React Native projects",
+    "main": "src/index.js",
+    "types": "index.d.ts",
+    "repository": "https://github.com/Kumulos/KumulosSdkReactNative",
+    "author": "Kumulos Ltd. <support@kumulos.com>",
+    "license": "MIT",
+    "dependencies": {
+        "base-64": "^0.1.0",
+        "raven-js": "^3.26.3"
+    },
+    "peerDependencies": {
+        "react-native": ">=0.59.0"
+    },
+    "devDependencies": {
+        "eslint": "^4.18.2"
+    },
+    "rnpm": {
+        "android": {
+            "sourceDir": "./src/android"
+        }
     }
-  }
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -36,6 +36,16 @@ repositories {
 dependencies {
     compileOnly 'com.facebook.react:react-native:+'
 
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:6.0.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:6.0.0'
+    debugImplementation ('com.kumulos.android:kumulos-android-debug:6.1.0') {
+        exclude group: 'com.squareup.okhttp3'
+        exclude module: 'okhttp3'
+        exclude group: 'com.android.support'
+        exclude module: 'support-annotation'
+    }
+    releaseImplementation ('com.kumulos.android:kumulos-android-release:6.1.0') {
+        exclude group: 'com.squareup.okhttp3'
+        exclude module: 'okhttp3'
+        exclude group: 'com.android.support'
+        exclude module: 'support-annotation'
+    }
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -16,11 +16,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
- Update Android base SDK to latest (6.1.0)
- Exclude conflicted Android dependency versions
- Update minimum RN version requirements
- Update integration steps & backwards compatibility table