### PR TITLE
Guard against handling pushes with unexpected data payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -42,7 +42,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     static PushMessage coldStartPush;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "5.1.2";
+    private static final String SDK_VERSION = "5.1.3";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -10,7 +10,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"5.1.2";
+static const NSString* KSReactNativeVersion = @"5.1.3";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 
@@ -81,11 +81,19 @@ static const NSUInteger KSRuntimeTypeReactNative = 7;
         [self sendEventWithName:@"kumulos.inApp.deepLinkPressed" body:data];
     };
     ksPushOpenedHandler = ^(KSPushNotification * _Nonnull notification) {
+        if (!notification.id) {
+            return;
+        }
+
         [self sendEventWithName:@"kumulos.push.opened" body:[self pushToDict:notification]];
     };
 
     if (@available(iOS 10.0, *)) {
         ksPushReceivedHandler = ^(KSPushNotification* _Nonnull notification, KSPushReceivedInForegroundCompletionHandler completionHandler) {
+            if (!notification.id) {
+                return;
+            }
+
             [self sendEventWithName:@"kumulos.push.received" body:[self pushToDict:notification]];
         };
     }


### PR DESCRIPTION
### Description of Changes

If an APNS payload is received which has a shape we don't expect, the handling of the notification can fail due to nil fields.

We resolve this by guarding against handling of notifications where we could not resolve an ID field from the payload.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [x] `package.json`
-   [x] `src/ios/KumulosReactNative.m`
-   [x] `src/android/.../KumulosReactNative.java`
-   [ ] ~~`README.md`~~

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM
