### PR TITLE
Fix ISO8601 formatting of inbox date items for APIs lower than 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.1.3",
+    "version": "5.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.1.3",
+    "version": "5.1.4",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -42,7 +42,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     static PushMessage coldStartPush;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "5.1.3";
+    private static final String SDK_VERSION = "5.1.4";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";
@@ -183,7 +183,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     @ReactMethod
     public void inAppGetInboxItems(Promise promise) {
         SimpleDateFormat formatter;
-        formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
+        formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         List<InAppInboxItem> inboxItems = KumulosInApp.getInboxItems(reactContext);

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -10,7 +10,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"5.1.3";
+static const NSString* KSReactNativeVersion = @"5.1.4";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 


### PR DESCRIPTION
The 'X' format character is introduced in API 24 so this formatting fails on older
API levels.

Previously used date formatting: https://mincong-h.github.io/2017/02/16/convert-date-to-string-in-java/

Now using a literal 'Z' to indicate UTC as this is valid in ISO8601.

### Description of Changes

(briefly outline the reason for changes, and describe what's been done)

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [x] `package.json`
-   [x] `src/ios/KumulosReactNative.m`
-   [x] `src/android/.../KumulosReactNative.java`
-   [ ] ~~`README.md`~~

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM
