### PR TITLE
Feature parity with native SDKs

### DIFF
--- a/KumulosReactNative.podspec
+++ b/KumulosReactNative.podspec
@@ -66,6 +66,6 @@ Pod::Spec.new do |spec|
   #  you can include multiple dependencies to ensure it works.
 
   spec.dependency "React"
-  spec.dependency "KumulosSdkObjectiveC", "~> 4.0"
+  spec.dependency "KumulosSdkObjectiveC", "~> 4.2"
 
 end

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ This project is licensed under the MIT license with portions licensed under the 
 
 ## React Native Version Support
 
-| RN Version        | SDK Version | Docs                                                                           |
-| ----------------- | ----------- | ------------------------------------------------------------------------------ |
-| >= 0.60           | 5.x, 4.x    | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/master/README.md) |
-| >= 0.59 && < 0.60 | 3.0.0       | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/3.0.0/README.md)  |
-| >= 0.46 && < 0.59 | 2.1.0       | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/2.1.0/README.md)  |
+| RN Version        | SDK Version   | Docs                                                                           |
+| ----------------- | ------------- | ------------------------------------------------------------------------------ |
+| >= 0.60           | 6.x, 5.x, 4.x | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/master/README.md) |
+| >= 0.59 && < 0.60 | 3.0.0         | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/3.0.0/README.md)  |
+| >= 0.46 && < 0.59 | 2.1.0         | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/2.1.0/README.md)  |

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ This project is licensed under the MIT license with portions licensed under the 
 
 ## React Native Version Support
 
-| RN Version        | SDK Version   | Docs                                                                           |
-| ----------------- | ------------- | ------------------------------------------------------------------------------ |
-| >= 0.60           | 6.x, 5.x, 4.x | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/master/README.md) |
-| >= 0.59 && < 0.60 | 3.0.0         | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/3.0.0/README.md)  |
-| >= 0.46 && < 0.59 | 2.1.0         | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/2.1.0/README.md)  |
+| RN Version        | SDK Version | Docs                                                                           |
+| ----------------- | ----------- | ------------------------------------------------------------------------------ |
+| >= 0.60           | 5.x, 4.x    | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/master/README.md) |
+| >= 0.59 && < 0.60 | 3.0.0       | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/3.0.0/README.md)  |
+| >= 0.46 && < 0.59 | 2.1.0       | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/2.1.0/README.md)  |

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,8 @@ interface PushNotification {
 interface PushChannelManager {
     /**
      * Subscribes to the channels given by unique ID
+     *
+     * Channels that don't exist will be created.
      */
     subscribe(uuids: string[]): Promise<Response>;
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -219,6 +219,12 @@ interface IKumulosInApp {
      * or in-app messaging is not configured.
      */
     updateConsentForUser: (consented: boolean) => void;
+
+    /**
+     * Requests the deletion of the message associated with a given inbox item.
+     * May fail if the item is no longer available or it was not found.
+     */
+    deleteMessageFromInbox: (item: InAppInboxItem) => Promise<void>;
 }
 
 declare const Kumulos: KumulosSdk;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.2.0",
+    "version": "6.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "kumulos-react-native",
-    "version": "6.0.0",
+    "version": "5.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "acorn": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+            "version": "5.7.4",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+            "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
             "dev": true
         },
         "acorn-jsx": {
@@ -673,18 +673,18 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
             }
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.2.1",
+    "version": "6.0.0",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "6.0.0",
+    "version": "5.3.0",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -41,13 +41,13 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-core:16.0.7'
 
-    debugApi ('com.kumulos.android:kumulos-android-debug:8.4.2') {
+    debugApi ('com.kumulos.android:kumulos-android-debug:9.0.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
         exclude group: 'com.android.support'
         exclude module: 'support-annotation'
     }
-    releaseApi ('com.kumulos.android:kumulos-android-release:8.4.2') {
+    releaseApi ('com.kumulos.android:kumulos-android-release:9.0.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
         exclude group: 'com.android.support'

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -44,13 +44,11 @@ dependencies {
     debugApi ('com.kumulos.android:kumulos-android-debug:9.0.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
-        exclude group: 'com.android.support'
         exclude module: 'support-annotation'
     }
     releaseApi ('com.kumulos.android:kumulos-android-release:9.0.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
-        exclude group: 'com.android.support'
         exclude module: 'support-annotation'
     }
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -44,11 +44,9 @@ dependencies {
     debugApi ('com.kumulos.android:kumulos-android-debug:9.0.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
-        exclude module: 'support-annotation'
     }
     releaseApi ('com.kumulos.android:kumulos-android-release:9.0.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
-        exclude module: 'support-annotation'
     }
 }

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -43,7 +43,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     static String coldStartActionId;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "6.0.0";
+    private static final String SDK_VERSION = "5.3.0";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -248,6 +248,26 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
         promise.reject("0", "Message not found");
     }
 
+    @ReactMethod
+    public void deleteMessageFromInbox(Integer id, Promise promise) {
+        List<InAppInboxItem> items = KumulosInApp.getInboxItems(reactContext);
+        for (InAppInboxItem item : items) {
+            if (id == item.getId()) {
+                Boolean result = KumulosInApp.deleteMessageFromInbox(reactContext, item);
+                if (result){
+                    promise.resolve(null);
+                }
+                else{
+                    promise.reject("Failed to delete message");
+                }
+
+                return;
+            }
+        }
+
+        promise.reject("0", "Message not found");
+    }
+
     private static class InAppDeepLinkHandler implements InAppDeepLinkHandlerInterface {
 
         @Override

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -43,7 +43,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     static String coldStartActionId;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "5.2.1";
+    private static final String SDK_VERSION = "6.0.0";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";

--- a/src/index.js
+++ b/src/index.js
@@ -268,4 +268,8 @@ export class KumulosInApp {
     static async presentInboxMessage(inboxItem) {
         return NativeModules.kumulos.inAppPresentItemWithId(inboxItem.id);
     }
+
+    static async deleteMessageFromInbox(inboxItem) {
+        return NativeModules.kumulos.deleteMessageFromInbox(inboxItem.id);
+    }
 }

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -10,7 +10,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"6.0.0";
+static const NSString* KSReactNativeVersion = @"5.3.0";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -213,6 +213,27 @@ RCT_EXPORT_METHOD(inAppPresentItemWithId:(NSNumber* _Nonnull)ident resolve:(RCTP
     reject(@"0", @"Message not found", nil);
 }
 
+
+RCT_EXPORT_METHOD(deleteMessageFromInbox:(NSNumber* _Nonnull)ident resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+    NSArray<KSInAppInboxItem*>* inboxItems = [KumulosInApp getInboxItems];
+    for (KSInAppInboxItem* msg in inboxItems) {
+        if ([msg.id isEqualToNumber:ident]) {
+            BOOL result = [KumulosInApp deleteMessageFromInbox:msg];
+
+            if (result) {
+                resolve(nil);
+            } else {
+                reject(@"0", @"Failed to present message", nil);
+            }
+
+            return;
+        }
+    }
+
+    reject(@"0", @"Message not found", nil);
+}
+
 RCT_EXPORT_METHOD(pushStoreToken:(NSString*) token)
 {
     // Data conversion from https://stackoverflow.com/a/7318062/543200

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -10,7 +10,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"5.2.1";
+static const NSString* KSReactNativeVersion = @"6.0.0";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 


### PR DESCRIPTION
### Description of Changes

Android. Up to androidSDK 9.0.0 including
1) Firebase/AndroidX dependencies
2) notification composer enhancements (big text, sendWhen, sounds)
3) inbox deletion

iOS. Up to objcSDK 4.2.2 including
1) delivery tracking
2) inbox deletion
3) incrementing badges

### Breaking Changes

-   Underlying android SDK uses AndroidX now, so, the apps will have to replace support libraries with AndroidX

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [x] `package.json`
-   [x] `src/ios/KumulosReactNative.m`
-   [x] `src/android/.../KumulosReactNative.java`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM
