### PR TITLE
Fix Folly header collision

### DIFF
--- a/KumulosReactNative.podspec
+++ b/KumulosReactNative.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |spec|
   spec.license      = "MIT"
   spec.author             = { "Kumulos Ltd." => "support@kumulos.com" }
   spec.platform     = :ios
-  spec.platform     = :ios, "8.0"
+  spec.platform     = :ios, "9.0"
   spec.source       = { :git => "https://github.com/Kumulos/KumulosSdkReactNative.git", :tag => "#{spec.version}" }
 
 

--- a/KumulosReactNative.podspec
+++ b/KumulosReactNative.podspec
@@ -66,6 +66,6 @@ Pod::Spec.new do |spec|
   #  you can include multiple dependencies to ensure it works.
 
   spec.dependency "React"
-  spec.dependency "KumulosSdkObjectiveC", "~> 4.2"
+  spec.dependency "KumulosSdkObjectiveC", "4.2.4"
 
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.3.1",
+    "version": "5.3.2",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,9 +1,10 @@
 module.exports = {
     dependency: {
         platforms: {
+            ios: {},
             android: {
-                sourceDir: 'src/android'
-            }
-        }
-    }
+                sourceDir: 'src/android',
+            },
+        },
+    },
 };

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -43,7 +43,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     static String coldStartActionId;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "5.3.1";
+    private static final String SDK_VERSION = "5.3.2";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -10,7 +10,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"5.3.1";
+static const NSString* KSReactNativeVersion = @"5.3.2";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 


### PR DESCRIPTION
### Description of Changes

- Fix header include problems failing builds with RN 0.63
- Update ObjectiveC dependency to include necessary header maps fix (see https://github.com/Kumulos/KumulosSdkObjectiveC/pull/51)

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [ ] `package.json`
-   [ ] `src/ios/KumulosReactNative.m`
-   [ ] `src/android/.../KumulosReactNative.java`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM
