### PR TITLE
Update SDK to match latest native SDKs (DDL + channel subscription endpoints)

### DIFF
--- a/KumulosReactNative.podspec
+++ b/KumulosReactNative.podspec
@@ -66,6 +66,6 @@ Pod::Spec.new do |spec|
   #  you can include multiple dependencies to ensure it works.
 
   spec.dependency "React"
-  spec.dependency "KumulosSdkObjectiveC", "4.2.4"
+  spec.dependency "KumulosSdkObjectiveC", "4.3.0"
 
 end

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,14 @@ interface PushNotification {
     actionId?: string;
 }
 
+enum DeepLinkResolution {
+    LookupFailed = "LOOKUP_FAILED",
+    LinkNotFound = "LINK_NOT_FOUND",
+    LinkExpired = "LINK_EXPIRED",
+    LinkLimitExceeded = "LINK_LIMIT_EXCEEDED",
+    LinkMatched = "LINK_MATCHED"
+}
+
 interface PushChannelManager {
     /**
      * Subscribes to the channels given by unique ID
@@ -79,6 +87,10 @@ interface KumulosConfig {
      * Called when a user taps a deep-link button from an in-app message. Handle the data payload as desired.
      */
     inAppDeepLinkHandler?: (data: { [key: string]: any }) => void;
+     /**
+     * Called when a user taps a deep-link which brings user to the app
+     */
+    deepLinkHandler?: (resolution: DeepLinkResolution, link: string, data: { [key: string]: any } | null) => void;
 }
 
 interface KumulosSdk {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.3.1",
+    "version": "5.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.3.2",
+    "version": "5.4.0",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -41,11 +41,11 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-core:16.0.7'
 
-    debugApi ('com.kumulos.android:kumulos-android-debug:11.3.0') {
+    debugApi ('com.kumulos.android:kumulos-android-debug:11.3.1') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
     }
-    releaseApi ('com.kumulos.android:kumulos-android-release:11.3.0') {
+    releaseApi ('com.kumulos.android:kumulos-android-release:11.3.1') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
     }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -41,11 +41,11 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-core:16.0.7'
 
-    debugApi ('com.kumulos.android:kumulos-android-debug:9.0.0') {
+    debugApi ('com.kumulos.android:kumulos-android-debug:11.3.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
     }
-    releaseApi ('com.kumulos.android:kumulos-android-release:9.0.0') {
+    releaseApi ('com.kumulos.android:kumulos-android-release:11.3.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
     }

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -332,8 +332,6 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
                     linkData.putMap("content", content);
 
                     linkData.putString("data", data.data.toString());
-
-
                     break;
                 case LINK_NOT_FOUND:
                     mappedResolution = "LINK_NOT_FOUND";

--- a/src/client.js
+++ b/src/client.js
@@ -13,6 +13,10 @@ export default class KumulosClient {
         return await NativeModules.kumulos.getInstallId();
     }
 
+    async getUserIdentifier() {
+        return await NativeModules.kumulos.getCurrentUserIdentifier();
+    }
+
     async call(method, params = {}) {
         let installId = null;
         try {

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,5 +1,6 @@
 export const BUILD_BASE_URL = 'https://api.kumulos.com';
 export const PUSH_BASE_URL = 'https://push.kumulos.com';
+export const CRM_BASE_URL = 'https://crm.kumulos.com';
 
 export const CrashReportFormat = 'raven';
 

--- a/src/index.js
+++ b/src/index.js
@@ -115,10 +115,12 @@ export default class Kumulos {
         if (config.deepLinkHandler) {
             Platform.select({
                 ios: () => {
-                    // kumulosEmitter.addListener(
-                    //     'kumulos.inApp.deepLinkPressed',
-                    //     config.inAppDeepLinkHandler
-                    // );
+                    kumulosEmitter.addListener(
+                        'kumulos.links.deepLinkPressed',
+                        event => {
+                            config.deepLinkHandler(event.resolution, event.link, event.linkData);
+                        }
+                    );
                 },
                 android: () => {
                     DeviceEventEmitter.addListener(
@@ -133,7 +135,9 @@ export default class Kumulos {
                 }
             })();
 
-            NativeModules.kumulos.deepLinkListenerRegistered();
+            if (Platform.OS === 'android'){
+                NativeModules.kumulos.deepLinkListenerRegistered();
+            }
         }
 
         if (empty(config.apiKey) || empty(config.secretKey)) {

--- a/src/index.js
+++ b/src/index.js
@@ -132,6 +132,8 @@ export default class Kumulos {
                     );
                 }
             })();
+
+            NativeModules.kumulos.deepLinkListenerRegistered();
         }
 
         if (empty(config.apiKey) || empty(config.secretKey)) {

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,28 @@ export default class Kumulos {
             })();
         }
 
+        if (config.deepLinkHandler) {
+            Platform.select({
+                ios: () => {
+                    // kumulosEmitter.addListener(
+                    //     'kumulos.inApp.deepLinkPressed',
+                    //     config.inAppDeepLinkHandler
+                    // );
+                },
+                android: () => {
+                    DeviceEventEmitter.addListener(
+                        'kumulos.links.deepLinkPressed',
+                        event => {
+                            if (event.linkData !== null){
+                                event.linkData.data = JSON.parse(event.linkData.data);
+                            }
+                            config.deepLinkHandler(event.resolution, event.link, event.linkData);
+                        }
+                    );
+                }
+            })();
+        }
+
         if (empty(config.apiKey) || empty(config.secretKey)) {
             throw 'API key and secret key are required options!';
         }
@@ -272,4 +294,12 @@ export class KumulosInApp {
     static async deleteMessageFromInbox(inboxItem) {
         return NativeModules.kumulos.deleteMessageFromInbox(inboxItem.id);
     }
+}
+
+export class DeepLinkResolution {
+    static LookupFailed = "LOOKUP_FAILED";
+    static LinkNotFound = "LINK_NOT_FOUND";
+    static LinkExpired = "LINK_EXPIRED";
+    static LinkLimitExceeded = "LINK_LIMIT_EXCEEDED";
+    static LinkMatched = "LINK_MATCHED";
 }

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -10,7 +10,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"5.3.2";
+static const NSString* KSReactNativeVersion = @"5.4.0";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 

--- a/src/push-channels.js
+++ b/src/push-channels.js
@@ -15,7 +15,7 @@ async function changeChannelSubscriptions(client, uuids, method, allowEmptyUuids
         return Promise.reject(new Error('could not get userIdentifier'));
     }
 
-    const url = `${CRM_BASE_URL}/v1/users/${encodeURI(userIdentifier)}/channels/subscriptions`;
+    const url = `${CRM_BASE_URL}/v1/users/${encodeURIComponent(userIdentifier)}/channels/subscriptions`;
 
     const data = {
         uuids: uuids
@@ -49,7 +49,7 @@ export class PushSubscriptionManager {
             return Promise.reject(new Error('could not get userIdentifier'));
         }
 
-        const url = `${CRM_BASE_URL}/v1/users/${encodeURI(userIdentifier)}/channels`;
+        const url = `${CRM_BASE_URL}/v1/users/${encodeURIComponent(userIdentifier)}/channels`;
 
         return makeAuthedJsonCall(this.client, 'GET', url)
             .then((response) => {

--- a/src/push-channels.js
+++ b/src/push-channels.js
@@ -1,4 +1,5 @@
-import { PUSH_BASE_URL } from './consts';
+import { CRM_BASE_URL, PUSH_BASE_URL } from './consts';
+
 import { makeAuthedJsonCall } from './utils';
 
 async function changeChannelSubscriptions(client, uuids, method, allowEmptyUuids) {
@@ -6,15 +7,15 @@ async function changeChannelSubscriptions(client, uuids, method, allowEmptyUuids
         return Promise.reject(new Error('Provide an array of channel uuids'));
     }
 
-    let installId = null;
+    let userIdentifier = null;
     try {
-        installId = await client.getInstallId();
+        userIdentifier = await client.getUserIdentifier();
     }
     catch (e) {
-        return Promise.reject(new Error('could not get installId'));
+        return Promise.reject(new Error('could not get userIdentifier'));
     }
 
-    const url = `${PUSH_BASE_URL}/v1/app-installs/${installId}/channels/subscriptions`;
+    const url = `${CRM_BASE_URL}/v1/users/${encodeURI(userIdentifier)}/channels/subscriptions`;
 
     const data = {
         uuids: uuids
@@ -40,15 +41,15 @@ export class PushSubscriptionManager {
     }
 
     async listChannels() {
-        let installId = null;
+        let userIdentifier = null;
         try {
-            installId = await this.client.getInstallId();
+            userIdentifier = await this.client.getUserIdentifier();
         }
         catch (e) {
-            return Promise.reject(new Error('could not get installId'));
+            return Promise.reject(new Error('could not get userIdentifier'));
         }
 
-        const url = `${PUSH_BASE_URL}/v1/app-installs/${installId}/channels`;
+        const url = `${CRM_BASE_URL}/v1/users/${encodeURI(userIdentifier)}/channels`;
 
         return makeAuthedJsonCall(this.client, 'GET', url)
             .then((response) => {
@@ -90,7 +91,7 @@ export class PushSubscriptionManager {
             return Promise.reject(new Error('Channel name must be specified for channel creation if the channel should be displayed in the portal'));
         }
 
-        const url = `${PUSH_BASE_URL}/v1/channels`;
+        const url = `${CRM_BASE_URL}/v1/channels`;
 
         let data = {
             uuid,
@@ -100,15 +101,15 @@ export class PushSubscriptionManager {
         };
 
         if (subscribe) {
-            let installId = null;
+            let userIdentifier = null;
             try {
-                installId = await this.client.getInstallId();
+                userIdentifier = await this.client.getUserIdentifier();
             }
             catch (e) {
-                return Promise.reject(new Error('could not get installId'));
+                return Promise.reject(new Error('could not get userIdentifier'));
             }
 
-            data.installId = installId;
+            data.userIdentifier = userIdentifier;
         }
 
         return makeAuthedJsonCall(this.client, 'POST', url, data)


### PR DESCRIPTION
### Description of Changes

1) Use new channel subscription management endpoints. No changes for users of the SDK
2) Add DDL. Often deep link is processed before communication between JS and Native is fully initialised. For both iOS and android cache DDL data, pass it to handler when event from JS-land comes.  

**Configuration**

```
Kumulos.initialize({
    apiKey: '',
    secretKey: '', 

    pushReceivedHandler: notification => {},
    pushOpenedHandler: notification => { },
    inAppDeepLinkHandler: data => {},
    deepLinkHandler: (resolution, link, data) => {
      // Called when a user taps a deep-link which brings user to the app
      switch(resolution){
        case DeepLinkResolution.LinkMatched:
          console.log(data);
          break;
      }
    },
  });
```



#### Integrating Android

1) Add intent filter to main activity:
```
<intent-filter android:label="hello" android:autoVerify="true">
                <action android:name="android.intent.action.VIEW" />
                <category android:name="android.intent.category.DEFAULT" />
                <category android:name="android.intent.category.BROWSABLE" />
                <!-- Accepts URIs that begin with "https://example.lnk.click/123”-->
                <data android:scheme="https"
                android:host="example.lnk.click"/>
</intent-filter>
```

2) Add the following lines to `onCreate` of the main activity
```
@Override
protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        Kumulos.seeIntent(this, getIntent(), savedInstanceState);
}
```

3) Add the following lines to `onWindowFocusChanged` of the main activity
```
public void onWindowFocusChanged(boolean hasFocus) {
        super.onWindowFocusChanged(hasFocus);
        Kumulos.seeInputFocus(this, hasFocus);
}
```

4) If main activity in AndroidManifest has `android:launchMode="singleTop"`, add following lines as well. It is advisable to have launch mode single top, as otherwise app link will create another copy of the activity on top of the stack if activity is already running. 
```
@Override
protected void onNewIntent(Intent intent) {
        super.onNewIntent(intent);
        Kumulos.seeIntent(this, intent);
}
```

#### Integrating iOS

```
// Non-scenes (AppDelegate.swift)
- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> *restorableObjects))restorationHandler {
    return [Kumulos application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
}


// Scenes (SceneDelegate.swift)
- (void) scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
    [Kumulos scene:scene continueUserActivity: userActivity];
}

- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions{
    if(![scene isKindOfClass:[UIWindowScene class]]){
        return;
    }
    
    // Deep links from cold starts
    NSUserActivity* userActivity = [[[connectionOptions userActivities] allObjects] firstObject];
    if (userActivity){
        [Kumulos scene:scene continueUserActivity: userActivity];
    }
}
```

Also, dont forget to add Associated Domains capability with `applinks:{subdomain}.lnk.click`

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-  ~~[ ] Check `pod lib lint` passes~~

Bump versions in:

-   [x] `package.json`
-   [x] `src/ios/KumulosReactNative.m`
-   [x] `src/android/.../KumulosReactNative.java`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM
