### PR TITLE
Bugfix: push opened handler not always firing

### DIFF
--- a/KumulosReactNative.podspec
+++ b/KumulosReactNative.podspec
@@ -66,6 +66,6 @@ Pod::Spec.new do |spec|
   #  you can include multiple dependencies to ensure it works.
 
   spec.dependency "React"
-  spec.dependency "KumulosSdkObjectiveC", "4.3.0"
+  spec.dependency "KumulosSdkObjectiveC", "4.4.0"
 
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "5.4.0",
+    "version": "5.4.1",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -2,6 +2,16 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+allprojects {
+    repositories {
+        maven {
+            // All of React Native (JS, Android binaries) is installed from npm
+            url "$rootDir/../node_modules/react-native/android"
+        }
+    }
+}
+
+
 buildscript {
     repositories {
         jcenter()
@@ -35,6 +45,7 @@ android {
 repositories {
     mavenCentral()
 }
+
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -57,7 +57,6 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
 
     private static boolean jsListenersRegistered = false;
     private static WritableMap deepLinkCachedData = null;
-    private static KumulosReactNative self;
 
     public static void initialize(Application application, KumulosConfig.Builder config) {
         KumulosInApp.setDeepLinkHandler(new InAppDeepLinkHandler());
@@ -90,8 +89,6 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
         super(reactContext);
         this.reactContext = reactContext;
         sharedReactContext = reactContext;
-
-        self = this;
     }
 
     @Override
@@ -328,13 +325,6 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
 
         KumulosReactNative.sharedReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit("kumulos.push.received", pushToMap(message, null));
-    }
-
-    static @Nullable Activity getActivity() {
-        if (self == null){
-            return null;
-        }
-        return self.getCurrentActivity();
     }
 
     private static WritableMap pushToMap(PushMessage push, String actionId) {

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -48,7 +48,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     static String coldStartActionId;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "5.4.0";
+    private static final String SDK_VERSION = "5.4.1";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -1,6 +1,7 @@
 
 package com.kumulos.reactnative;
 
+import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.location.Location;
@@ -56,6 +57,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
 
     private static boolean jsListenersRegistered = false;
     private static WritableMap deepLinkCachedData = null;
+    private static KumulosReactNative self;
 
     public static void initialize(Application application, KumulosConfig.Builder config) {
         KumulosInApp.setDeepLinkHandler(new InAppDeepLinkHandler());
@@ -88,6 +90,8 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
         super(reactContext);
         this.reactContext = reactContext;
         sharedReactContext = reactContext;
+
+        self = this;
     }
 
     @Override
@@ -324,6 +328,13 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
 
         KumulosReactNative.sharedReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit("kumulos.push.received", pushToMap(message, null));
+    }
+
+    static @Nullable Activity getActivity() {
+        if (self == null){
+            return null;
+        }
+        return self.getCurrentActivity();
     }
 
     private static WritableMap pushToMap(PushMessage push, String actionId) {

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -101,7 +101,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
 
         if (null != coldStartPush) {
             sharedReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                    .emit("kumulos.push.received", PushReceiver.pushToMap(coldStartPush, coldStartActionId));
+                    .emit("kumulos.push.opened", PushReceiver.pushToMap(coldStartPush, coldStartActionId));
 
             coldStartPush = null;
             coldStartActionId = null;

--- a/src/android/src/main/java/com/kumulos/reactnative/PushReceiver.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/PushReceiver.java
@@ -53,16 +53,25 @@ public class PushReceiver extends PushBroadcastReceiver {
             return;
         }
 
-        if (null != pushMessage.getUrl()) {
-            launchIntent = new Intent(Intent.ACTION_VIEW, pushMessage.getUrl());
-        }
-
-        launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        addDeepLinkExtras(pushMessage, launchIntent);
-
         maybeAddDeepLinkExtrasToExistingIntent(pushMessage);
 
-        context.startActivity(launchIntent);
+        if (null != pushMessage.getUrl()) {
+            launchIntent = new Intent(Intent.ACTION_VIEW, pushMessage.getUrl());
+
+            addDeepLinkExtras(pushMessage, launchIntent);
+
+            TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+            taskStackBuilder.addParentStack(component);
+            taskStackBuilder.addNextIntent(launchIntent);
+            taskStackBuilder.startActivities();
+        }
+        else{
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+            addDeepLinkExtras(pushMessage, launchIntent);
+
+            context.startActivity(launchIntent);
+        }
 
         JSONObject deepLink = pushMessage.getData().optJSONObject("k.deepLink");
         if (null != deepLink) {

--- a/src/android/src/main/java/com/kumulos/reactnative/PushReceiver.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/PushReceiver.java
@@ -60,11 +60,7 @@ public class PushReceiver extends PushBroadcastReceiver {
         launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         addDeepLinkExtras(pushMessage, launchIntent);
 
-        Activity currentActivity = KumulosReactNative.getActivity();
-        if (currentActivity != null){
-            Intent existingIntent = currentActivity.getIntent();
-            addDeepLinkExtras(pushMessage, existingIntent);
-        }
+        maybeAddDeepLinkExtrasToExistingIntent(pushMessage);
 
         context.startActivity(launchIntent);
 
@@ -74,6 +70,20 @@ public class PushReceiver extends PushBroadcastReceiver {
         }
 
         KumulosReactNative.emitOrCachePushOpen(pushMessage, null);
+    }
+
+    private static void maybeAddDeepLinkExtrasToExistingIntent(PushMessage pushMessage){
+        if (KumulosReactNative.sharedReactContext == null){
+            return;
+        }
+
+        Activity currentActivity = KumulosReactNative.sharedReactContext.getCurrentActivity();
+        if (currentActivity == null){
+            return;
+        }
+
+        Intent existingIntent = currentActivity.getIntent();
+        addDeepLinkExtras(pushMessage, existingIntent);
     }
 
     static class PushActionHandler implements PushActionHandlerInterface {

--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ export default class Kumulos {
             })();
 
             if (Platform.OS === 'android'){
-                NativeModules.kumulos.deepLinkListenerRegistered();
+                NativeModules.kumulos.jsListenersRegistered();
             }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -134,10 +134,10 @@ export default class Kumulos {
                     );
                 }
             })();
+        }
 
-            if (Platform.OS === 'android'){
-                NativeModules.kumulos.jsListenersRegistered();
-            }
+        if (Platform.OS === 'android'){
+            NativeModules.kumulos.jsListenersRegistered();
         }
 
         if (empty(config.apiKey) || empty(config.secretKey)) {

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -11,7 +11,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"5.4.0";
+static const NSString* KSReactNativeVersion = @"5.4.1";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 


### PR DESCRIPTION
### Description of Changes

1) Raise correct `kumulos.push.opened` event when app launches from push open
2) update to latest ObjC having locale bugfix
3) Always notify native when js listeners are added. Store and emit cold start push opens similar to deep linking.
4) Like in CordovaSDK make activity launch intent single top (when push open new activity not launched if already exists)

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [x] `package.json`
-   [x] `src/ios/KumulosReactNative.m`
-   [x] `src/android/.../KumulosReactNative.java`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM
