### PR TITLE
 Android Channel Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -54,11 +54,11 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 
-    debugApi ('com.kumulos.android:kumulos-android-debug:12.0.0') {
+    debugApi ('com.kumulos.android:kumulos-android-debug:12.1.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
     }
-    releaseApi ('com.kumulos.android:kumulos-android-release:12.0.0') {
+    releaseApi ('com.kumulos.android:kumulos-android-release:12.1.0') {
         exclude group: 'com.squareup.okhttp3'
         exclude module: 'okhttp3'
     }

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -51,7 +51,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     private static WritableMap cachedPushOpen;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "6.0.0";
+    private static final String SDK_VERSION = "6.1.0";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -12,7 +12,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"6.0.0";
+static const NSString* KSReactNativeVersion = @"6.1.0";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 


### PR DESCRIPTION
### Description of Changes

- notificationType: Hint to the SDK whether a notification should default to the tray or a banner (priority default or max respectively), this is automatic and handled between the Kumulos push pipeline and the SDK.

- notificationChannel: If the app developer has setup specific channels for content then setting this key will forward it to the end consumer and is readable on the PushMessage object.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [x] `package.json`
-   [x] `src/ios/KumulosReactNative.m`
-   [x] `src/android/.../KumulosReactNative.java`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM
