### PR TITLE
Fix promise chain for rejection paths in push channel manager

### DIFF
--- a/src/push-channels.js
+++ b/src/push-channels.js
@@ -24,10 +24,10 @@ async function changeChannelSubscriptions(client, uuids, method, allowEmptyUuids
     return makeAuthedJsonCall(client, method, url, data)
         .then((response) => {
             if (response.status === 404) {
-                Promise.reject(new Error('some channels are not found: status: ' + response.status));
+                return Promise.reject(new Error('some channels are not found: status: ' + response.status));
             }
             else if (!response.ok) {
-                Promise.reject(new Error('failed to update channel subscription. status: ' + response.status));
+                return Promise.reject(new Error('failed to update channel subscription. status: ' + response.status));
             }
 
             return response;
@@ -54,7 +54,7 @@ export class PushSubscriptionManager {
         return makeAuthedJsonCall(this.client, 'GET', url)
             .then((response) => {
                 if (!response.ok) {
-                    Promise.reject(new Error('failed to list channels. status: ' + response.status));
+                    return Promise.reject(new Error('failed to list channels. status: ' + response.status));
                 }
                 else {
                     return response.json();
@@ -115,7 +115,7 @@ export class PushSubscriptionManager {
         return makeAuthedJsonCall(this.client, 'POST', url, data)
             .then((response) => {
                 if (!response.ok) {
-                    Promise.reject(new Error('failed to create channel. status: ' + response.status));
+                    return Promise.reject(new Error('failed to create channel. status: ' + response.status));
                 }
 
                 return response.json();


### PR DESCRIPTION
### Description of Changes

Some error branches didn't correctly return the rejection to continue the promise chain.

Address this by returning the rejections.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

~~Bump versions in:~~  **Holding for release with other patches**

-   [ ] `package.json`
-   [ ] `src/ios/KumulosReactNative.m`
-   [ ] `src/android/.../KumulosReactNative.java`
-   [ ] `README.md`

~~Release:~~  **Holding for release with other patches**

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM

Update changelog:

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/react-native/#changelog

