### PR TITLE
Fix in-app inbox item handling of null data payloads on iOS

### DIFF
--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -279,7 +279,7 @@ RCT_EXPORT_METHOD(inAppGetInboxItems:(RCTPromiseResolveBlock)resolve reject:(RCT
                            @"dismissedAt": item.dismissedAt ? [formatter stringFromDate:item.dismissedAt] : NSNull.null,
                            @"isRead": @([item isRead]),
                            @"sentAt": item.sentAt ? [formatter stringFromDate:item.sentAt] : NSNull.null,
-                           @"data": item.data,
+                           @"data": item.data ?: NSNull.null,
                            @"imageUrl": imageUrl ? imageUrl.absoluteString : NSNull.null
         }];
     }


### PR DESCRIPTION
### Description of Changes

The KSInAppInboxItem model defines data as _Nullable, but the mapping to NSDictionary for passing to RN through the bridge doens't handle this case properly.

It will try to pass nil to the dictionary literal and throw an exception as dictionaries are not allowed to contain simple types.

Fix by passing NSNull instead if the data is nil.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [ ] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [ ] `package.json`
-   [ ] `src/ios/KumulosReactNative.m`
-   [ ] `src/android/.../KumulosReactNative.java`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/react-native/#changelog

