### PR TITLE
Remove Kumulos Crash Reporting feature

### DIFF
--- a/KumulosReactNative.podspec
+++ b/KumulosReactNative.podspec
@@ -66,6 +66,6 @@ Pod::Spec.new do |spec|
   #  you can include multiple dependencies to ensure it works.
 
   spec.dependency "React"
-  spec.dependency "KumulosSdkObjectiveC", "4.6.0"
+  spec.dependency "KumulosSdkObjectiveC", "6.0.0"
 
 end

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ This project is licensed under the MIT license with portions licensed under the 
 
 ## React Native Version Support
 
-| RN Version        | SDK Version   | Docs                                                                           |
-| ----------------- | ------------- | ------------------------------------------------------------------------------ |
-| >= 0.60           | 6.x, 5.x, 4.x | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/master/README.md) |
-| >= 0.59 && < 0.60 | 3.0.0         | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/3.0.0/README.md)  |
-| >= 0.46 && < 0.59 | 2.1.0         | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/2.1.0/README.md)  |
+| RN Version        | SDK Version             | Docs                                                                           |
+| ----------------- | ----------------------- | ------------------------------------------------------------------------------ |
+| >= 0.60           | 8.x, 7.x, 6.x, 5.x, 4.x | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/master/README.md) |
+| >= 0.59 && < 0.60 | 3.0.0                   | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/3.0.0/README.md)  |
+| >= 0.46 && < 0.59 | 2.1.0                   | [Docs](https://github.com/Kumulos/KumulosSdkReactNative/blob/2.1.0/README.md)  |

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,11 +23,11 @@ interface PushNotification {
 }
 
 enum DeepLinkResolution {
-    LookupFailed = "LOOKUP_FAILED",
-    LinkNotFound = "LINK_NOT_FOUND",
-    LinkExpired = "LINK_EXPIRED",
-    LinkLimitExceeded = "LINK_LIMIT_EXCEEDED",
-    LinkMatched = "LINK_MATCHED"
+    LookupFailed = 'LOOKUP_FAILED',
+    LinkNotFound = 'LINK_NOT_FOUND',
+    LinkExpired = 'LINK_EXPIRED',
+    LinkLimitExceeded = 'LINK_LIMIT_EXCEEDED',
+    LinkMatched = 'LINK_MATCHED',
 }
 
 interface PushChannelManager {
@@ -67,15 +67,6 @@ interface KumulosConfig {
     apiKey: string;
     secretKey: string;
     /**
-     * Turn crash reporting on (defaults to false)
-     */
-    enableCrashReporting?: boolean;
-    /**
-     * A version identifier for minified source maps you upload
-     * used in JS error reporting source mapping
-     */
-    sourceMapTag?: string;
-    /**
      * Called when a push notification is received and your app is in the foreground
      */
     pushReceivedHandler?: (notification: PushNotification) => void;
@@ -87,10 +78,14 @@ interface KumulosConfig {
      * Called when a user taps a deep-link button from an in-app message. Handle the data payload as desired.
      */
     inAppDeepLinkHandler?: (data: { [key: string]: any }) => void;
-     /**
+    /**
      * Called when a user taps a deep-link which brings user to the app
      */
-    deepLinkHandler?: (resolution: DeepLinkResolution, link: string, data: { [key: string]: any } | null) => void;
+    deepLinkHandler?: (
+        resolution: DeepLinkResolution,
+        link: string,
+        data: { [key: string]: any } | null
+    ) => void;
 }
 
 interface KumulosSdk {
@@ -147,20 +142,6 @@ interface KumulosSdk {
      * After being recorded locally, all stored events will be flushed to the server.
      */
     trackEventImmediately: (eventType: string, properties?: {}) => void;
-
-    /**
-     * Logs an exception to the Kumulos Crash reporting service
-     *
-     * Use this method to record unexpected application state
-     */
-    logException: (e: any, context?: {}) => void;
-
-    /**
-     * Logs an uncaught exception to the Kumulos Crash reporting service
-     *
-     * Use this method to forward exceptions from other error handlers.
-     */
-    logUncaughtException: (e: any) => void;
 
     /**
      * Updates the location of the current installation in Kumulos

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "7.0.0",
+    "version": "8.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,10 @@
     "packages": {
         "": {
             "name": "kumulos-react-native",
-            "version": "7.0.0",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
-                "base-64": "^0.1.0",
-                "raven-js": "^3.26.3"
+                "base-64": "^0.1.0"
             },
             "devDependencies": {
                 "eslint": "^4.18.2"
@@ -94,9 +93,9 @@
             "peer": true
         },
         "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -160,9 +159,9 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -247,9 +246,9 @@
             "peer": true
         },
         "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -1544,9 +1543,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -1764,9 +1763,9 @@
             }
         },
         "node_modules/@babel/preset-env/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -2544,9 +2543,9 @@
             }
         },
         "node_modules/@react-native-community/cli/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -2604,9 +2603,9 @@
             }
         },
         "node_modules/@sideway/formula": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-            "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
             "peer": true
         },
         "node_modules/@sideway/pinpoint": {
@@ -3058,9 +3057,9 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -3247,26 +3246,35 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.16.6",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001219",
-                "colorette": "^1.2.2",
-                "electron-to-chromium": "^1.3.723",
-                "escalade": "^3.1.1",
-                "node-releases": "^1.1.71"
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
+                "node-releases": "^2.0.13",
+                "update-browserslist-db": "^1.0.13"
             },
             "bin": {
                 "browserslist": "cli.js"
             },
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
             }
         },
         "node_modules/bser": {
@@ -3380,14 +3388,24 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001242",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-            "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
-            "peer": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "version": "1.0.30001549",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001549.tgz",
+            "integrity": "sha512-qRp48dPYSCYaP+KurZLhDYdVE+yEyht/3NlmcJgVQ2VMGt6JL36ndQ/7rgspdZsJuxDPFIo/OzBT2+GmIJ53BA==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "peer": true
         },
         "node_modules/capture-exit": {
             "version": "2.0.0",
@@ -3848,26 +3866,16 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.15.2",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
-            "integrity": "sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==",
+            "version": "3.33.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.0.tgz",
+            "integrity": "sha512-0w4LcLXsVEuNkIqwjjf9rjCoPhK8uqA4tMRh4Ge26vfLtUutshn+aRJU21I9LCJlh2QQHfisNToLjw1XEJLTWw==",
             "peer": true,
             "dependencies": {
-                "browserslist": "^4.16.6",
-                "semver": "7.0.0"
+                "browserslist": "^4.22.1"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/core-js-compat/node_modules/semver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-            "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/core-util-is": {
@@ -3908,9 +3916,9 @@
             "peer": true
         },
         "node_modules/debug": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
@@ -3926,9 +3934,9 @@
             }
         },
         "node_modules/decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "peer": true,
             "engines": {
                 "node": ">=0.10"
@@ -4023,9 +4031,9 @@
             "peer": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.768",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz",
-            "integrity": "sha512-I4UMZHhVSK2pwt8jOIxTi3GIuc41NkddtKT/hpuxp9GO5UWJgDKTBa4TACppbVAuKtKbMK6BhQZvT5tFF1bcNA==",
+            "version": "1.4.554",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
+            "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ==",
             "peer": true
         },
         "node_modules/emoji-regex": {
@@ -5809,13 +5817,10 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "peer": true,
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -6542,9 +6547,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6698,9 +6703,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "1.1.73",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-            "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
             "peer": true
         },
         "node_modules/node-stream-zip": {
@@ -7131,6 +7136,12 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "peer": true
         },
+        "node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "peer": true
+        },
         "node_modules/picomatch": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -7396,11 +7407,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/raven-js": {
-            "version": "3.27.0",
-            "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.0.tgz",
-            "integrity": "sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw=="
         },
         "node_modules/react": {
             "version": "17.0.1",
@@ -8032,9 +8038,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "bin": {
                 "semver": "bin/semver"
             }
@@ -9082,6 +9088,36 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/update-browserslist-db": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "peer": true,
+            "dependencies": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
         "node_modules/urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -9536,9 +9572,9 @@
                     "peer": true
                 },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "peer": true
                 }
             }
@@ -9586,9 +9622,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "peer": true
                 }
             }
@@ -9649,9 +9685,9 @@
                     "peer": true
                 },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "peer": true
                 }
             }
@@ -10515,9 +10551,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "peer": true
                 }
             }
@@ -10680,9 +10716,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "peer": true
                 }
             }
@@ -10989,9 +11025,9 @@
                     "peer": true
                 },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "peer": true
                 },
                 "strip-ansi": {
@@ -11353,9 +11389,9 @@
             }
         },
         "@sideway/formula": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-            "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
             "peer": true
         },
         "@sideway/pinpoint": {
@@ -11733,9 +11769,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "peer": true
                 }
             }
@@ -11885,16 +11921,15 @@
             }
         },
         "browserslist": {
-            "version": "4.16.6",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "peer": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001219",
-                "colorette": "^1.2.2",
-                "electron-to-chromium": "^1.3.723",
-                "escalade": "^3.1.1",
-                "node-releases": "^1.1.71"
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
+                "node-releases": "^2.0.13",
+                "update-browserslist-db": "^1.0.13"
             }
         },
         "bser": {
@@ -11983,9 +12018,9 @@
             "peer": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001242",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-            "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+            "version": "1.0.30001549",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001549.tgz",
+            "integrity": "sha512-qRp48dPYSCYaP+KurZLhDYdVE+yEyht/3NlmcJgVQ2VMGt6JL36ndQ/7rgspdZsJuxDPFIo/OzBT2+GmIJ53BA==",
             "peer": true
         },
         "capture-exit": {
@@ -12373,21 +12408,12 @@
             "peer": true
         },
         "core-js-compat": {
-            "version": "3.15.2",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
-            "integrity": "sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==",
+            "version": "3.33.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.0.tgz",
+            "integrity": "sha512-0w4LcLXsVEuNkIqwjjf9rjCoPhK8uqA4tMRh4Ge26vfLtUutshn+aRJU21I9LCJlh2QQHfisNToLjw1XEJLTWw==",
             "peer": true,
             "requires": {
-                "browserslist": "^4.16.6",
-                "semver": "7.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-                    "peer": true
-                }
+                "browserslist": "^4.22.1"
             }
         },
         "core-util-is": {
@@ -12425,9 +12451,9 @@
             "peer": true
         },
         "debug": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "requires": {
                 "ms": "^2.1.1"
@@ -12440,9 +12466,9 @@
             "peer": true
         },
         "decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "peer": true
         },
         "deep-is": {
@@ -12519,9 +12545,9 @@
             "peer": true
         },
         "electron-to-chromium": {
-            "version": "1.3.768",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz",
-            "integrity": "sha512-I4UMZHhVSK2pwt8jOIxTi3GIuc41NkddtKT/hpuxp9GO5UWJgDKTBa4TACppbVAuKtKbMK6BhQZvT5tFF1bcNA==",
+            "version": "1.4.554",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
+            "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ==",
             "peer": true
         },
         "emoji-regex": {
@@ -13940,13 +13966,10 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "peer": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "peer": true
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -14575,9 +14598,9 @@
             "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -14696,9 +14719,9 @@
             "peer": true
         },
         "node-releases": {
-            "version": "1.1.73",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-            "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
             "peer": true
         },
         "node-stream-zip": {
@@ -15020,6 +15043,12 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "peer": true
         },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "peer": true
+        },
         "picomatch": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -15228,11 +15257,6 @@
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "peer": true
-        },
-        "raven-js": {
-            "version": "3.27.0",
-            "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.0.tgz",
-            "integrity": "sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw=="
         },
         "react": {
             "version": "17.0.1",
@@ -15751,9 +15775,9 @@
             }
         },
         "semver": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "send": {
             "version": "0.17.1",
@@ -16608,6 +16632,16 @@
                     "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
                     "peer": true
                 }
+            }
+        },
+        "update-browserslist-db": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "peer": true,
+            "requires": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
             }
         },
         "urix": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kumulos-react-native",
-    "version": "7.0.0",
+    "version": "8.0.0",
     "description": "Official SDK for integrating Kumulos services with your React Native projects",
     "main": "src/index.js",
     "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "author": "Kumulos Ltd. <support@kumulos.com>",
     "license": "MIT",
     "dependencies": {
-        "base-64": "^0.1.0",
-        "raven-js": "^3.26.3"
+        "base-64": "^0.1.0"
     },
     "peerDependencies": {
         "react-native": ">=0.60.0"

--- a/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
+++ b/src/android/src/main/java/com/kumulos/reactnative/KumulosReactNative.java
@@ -53,7 +53,7 @@ public class KumulosReactNative extends ReactContextBaseJavaModule {
     static ReactContext sharedReactContext;
 
     private static final int SDK_TYPE = 9;
-    private static final String SDK_VERSION = "7.0.0";
+    private static final String SDK_VERSION = "8.0.0";
     private static final int RUNTIME_TYPE = 7;
     private static final int PUSH_TOKEN_TYPE = 2;
     private static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";

--- a/src/consts.js
+++ b/src/consts.js
@@ -2,19 +2,16 @@ export const BUILD_BASE_URL = 'https://api.kumulos.com';
 export const PUSH_BASE_URL = 'https://push.kumulos.com';
 export const CRM_BASE_URL = 'https://crm.kumulos.com';
 
-export const CrashReportFormat = 'raven';
-
 export const KumulosEvent = {
     AppForegrounded: 'k.fg',
     PushTrackOpen: 'k.push.opened',
     EngageBeaconEnteredProximity: 'k.engage.beaconEnteredProximity',
     EngageLocationUpdated: 'k.engage.locationUpdated',
-    CrashLoggedException: 'k.crash.loggedException'
 };
 
 export const BeaconType = {
     iBeacon: 1,
-    Eddystone: 2
+    Eddystone: 2,
 };
 
 export const ResponseCode = {
@@ -25,5 +22,5 @@ export const ResponseCode = {
     ACCOUNT_SUSPENDED: 16,
     INVALID_REQUEST: 32,
     UNKNOWN_SERVER_ERROR: 64,
-    DATABASE_ERROR: 128
+    DATABASE_ERROR: 128,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { BeaconType, CrashReportFormat, KumulosEvent } from './consts';
+import { BeaconType, KumulosEvent } from './consts';
 import {
     DeviceEventEmitter,
     NativeEventEmitter,
@@ -9,37 +9,11 @@ import { empty, nullOrUndefined } from './utils';
 
 import KumulosClient from './client';
 import { PushSubscriptionManager } from './push-channels';
-import Raven from 'raven-js';
-import RavenReactNativePlugin from 'raven-js/plugins/react-native';
 
 let initialized = false;
 let clientInstance = null;
-let currentConfig = null;
-
-let ravenInstance = null;
-let exceptionsDuringInit = [];
 
 const kumulosEmitter = new NativeEventEmitter(NativeModules.kumulos);
-
-function logException(e, uncaught, context = undefined) {
-    if (!initialized || !currentConfig.enableCrashReporting) {
-        console.log(
-            'Crash reporting has not been enabled, ignoring exception:'
-        );
-        console.error(e);
-        return;
-    }
-
-    if (!ravenInstance) {
-        exceptionsDuringInit.push([e, uncaught, context]);
-        return;
-    }
-
-    ravenInstance.captureException(e, {
-        uncaught,
-        extra: context
-    });
-}
 
 export default class Kumulos {
     static initialize(config) {
@@ -144,61 +118,13 @@ export default class Kumulos {
             throw 'API key and secret key are required options!';
         }
 
-        const enableCrashReporting = nullOrUndefined(
-            config.enableCrashReporting
-        )
-            ? 0
-            : Number(config.enableCrashReporting);
-
         clientInstance = new KumulosClient(config);
-        currentConfig = config;
-
-        if (enableCrashReporting) {
-            RavenReactNativePlugin(Raven);
-
-            const transport = report => {
-                Kumulos.trackEvent(KumulosEvent.CrashLoggedException, {
-                    format: CrashReportFormat,
-                    report: report.data
-                });
-
-                report.onSuccess();
-            };
-
-            let ravenOpts = {
-                transport
-            };
-
-            if (config.sourceMapTag) {
-                ravenOpts.release = config.sourceMapTag;
-            }
-
-            ravenInstance = Raven.config(
-                'https://nokey@crash.kumulos.com/raven',
-                ravenOpts
-            );
-
-            ravenInstance.install();
-
-            exceptionsDuringInit.forEach(args =>
-                logException.apply(this, args)
-            );
-            exceptionsDuringInit = [];
-        }
 
         initialized = true;
     }
 
     static getInstallId() {
         return clientInstance.getInstallId();
-    }
-
-    static logException(e, context = {}) {
-        logException(e, false, context);
-    }
-
-    static logUncaughtException(e) {
-        logException(e, true);
     }
 
     static call(method, params = {}) {

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -28,9 +28,9 @@ static NSMutableDictionary* deepLinkCachedData = nil;
 //}
 
 + (void)initializeWithConfig:(KSConfig*)config {
-    [config setInAppDeepLinkHandler:^(NSDictionary * _Nonnull data) {
+    [config setInAppDeepLinkHandler:^(KSInAppButtonPress * _Nonnull buttonPress) {
         if (ksInAppDeepLinkHandler) {
-            ksInAppDeepLinkHandler(data);
+            ksInAppDeepLinkHandler(buttonPress);
         }
     }];
 
@@ -153,8 +153,8 @@ static NSMutableDictionary* deepLinkCachedData = nil;
 }
 
 - (void)startObserving {
-    ksInAppDeepLinkHandler = ^(NSDictionary * _Nonnull data) {
-        [self sendEventWithName:@"kumulos.inApp.deepLinkPressed" body:data];
+    ksInAppDeepLinkHandler = ^(KSInAppButtonPress * _Nonnull buttonPress) {
+        [self sendEventWithName:@"kumulos.inApp.deepLinkPressed" body:buttonPress.deepLinkData];
     };
 
     ksDeepLinkTransmitter = ^(NSMutableDictionary* params) {

--- a/src/ios/KumulosReactNative.m
+++ b/src/ios/KumulosReactNative.m
@@ -12,7 +12,7 @@ API_AVAILABLE(ios(10.0))
 static KSPushReceivedInForegroundHandlerBlock ksPushReceivedHandler;
 static KSPushNotification* _Nullable ksColdStartPush;
 
-static const NSString* KSReactNativeVersion = @"7.0.0";
+static const NSString* KSReactNativeVersion = @"8.0.0";
 static const NSUInteger KSSdkTypeReactNative = 9;
 static const NSUInteger KSRuntimeTypeReactNative = 7;
 


### PR DESCRIPTION
### Description of Changes

- Remove all public APIs & dependencies related to the retired Crash Reporting feature.
- Update iOS base SDK to version 6.0.0 (JS in-app deep link handler shape kept as it was for minimal breaking changes)

### Breaking Changes

-   Remove crash reporting

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] ~~Check `pod lib lint` passes~~

Bump versions in:

-   [x] `package.json`
-   [x] `src/ios/KumulosReactNative.m`
-   [x] `src/android/.../KumulosReactNative.java`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `npm publish` to push to NPM

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/react-native/#changelog

